### PR TITLE
config: add python-click tests bcond

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -453,6 +453,9 @@ withouts = ["tests"]
 [[bconds.python-werkzeug]]
 withouts = ["tests"]
 
+[[bconds.python-click]]
+withouts = ["tests"]
+
 # [[bconds.OpenColorIO]]
 # %global bootstrap 1
 # we lack config syntax for that :(


### PR DESCRIPTION
With the tests bcond off, only python3-flit-core is needed to build click.

Relates: https://src.fedoraproject.org/rpms/python-click/pull-request/24