### PR TITLE
Drop python-wheel from the initial bootstrap sequence

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,9 +20,6 @@
 #- python-setuptools:
 #    macros:
 #      %global _with_bootstrap 1  # bump the release so it's greater even with ~bootstrap
-#- python-wheel:
-#    macros:
-#      %global _with_bootstrap 1  # bump the release so it's greater even with ~bootstrap
 #- python-pip:
 #    macros:
 #      %global _without_tests 1


### PR DESCRIPTION
Depends-On: https://src.fedoraproject.org/rpms/python-wheel/pull-request/39 (perhaps not)
Depends-On: https://src.fedoraproject.org/rpms/python-pip/pull-request/149