### PR TITLE
Refactoring of the scripts (broke down spaghetti, added tests), minor fixes

### DIFF
--- a/bconds.py
+++ b/bconds.py
@@ -135,39 +135,82 @@ def handle_existing_koji_id(repopath, *, was_updated):
                 return koji_task_id
 
 
-def scratchbuild_patched_if_needed(component_name, bcond_config, *, branch='', target='', no_git_refresh=False):
+def check_existing_artifacts(repopath, was_updated, bcond_config):
     """
-    This will:
-     1. clone/fetch the given component_name package from Fedora to fedpkg_cache_dir
-        in case the repo existed and HEAD was not updated, this ends early if:
-          - a SRPM exists
-          - a previously stored Koji task ID is present and not canceled or failed
-          (both information is added to the provided bcond_config)
-     2. change the specfile to apply the given bcond/macro config
-     3. scratchbuild the package in Koji (in a given target if specified)
-     4. cleanup the generated SRPM
-     5. write the Koji ID to KOJI_ID_FILENAME in the repo directory and to bcond_config
-     6. return True if something was submitted to Koji
+    Check if we can reuse existing SRPM or Koji task.
+    
+    Args:
+        repopath: Path to the repository
+        was_updated: Whether the repository was just updated
+        bcond_config: Configuration dict to update with found artifacts
+    
+    Returns:
+        bool: True if existing artifact found and can be reused (no rebuild needed)
     """
-    repopath = pathlib.Path(CONFIG['cache_dir']['fedpkg']) / bcond_config['id']
-
-    news = refresh_or_clone(repopath, component_name, no_git_refresh=no_git_refresh, branch=branch)
-
-    if srpm := handle_existing_srpm(repopath, was_updated=news):
+    if srpm := handle_existing_srpm(repopath, was_updated=was_updated):
         bcond_config['srpm'] = srpm
-        return False
-
-    if koji_id := handle_existing_koji_id(repopath, was_updated=news):
+        return True
+    
+    if koji_id := handle_existing_koji_id(repopath, was_updated=was_updated):
         bcond_config['koji_task_id'] = koji_id
-        return False
+        return True
+    
+    return False
 
+
+def prepare_spec_for_build(component_name, repopath, bcond_config):
+    """
+    Prepare the spec file by applying bcond patches and optionally bumping release.
+    
+    Args:
+        component_name: Name of the component
+        repopath: Path to the repository
+        bcond_config: Configuration with bcond settings
+    
+    Returns:
+        Path to the prepared spec file
+    """
     specpath = repopath / f'{component_name}.spec'
     patch_spec(specpath, bcond_config)
+    
     if 'bootstrap' in bcond_config.get('withs', ()):
         # bump the release not to create an older EVR with ~bootstrap
         # this is useful if we build the testing SRPMs in copr
         run('rpmdev-bumpspec', '--rightmost', specpath)
+    
+    return specpath
 
+
+def scratchbuild_patched_if_needed(component_name, bcond_config, *, branch='', target='', no_git_refresh=False):
+    """
+    Clone/refresh a component repository and submit a Koji scratchbuild if needed.
+    
+    This function:
+     1. Clones/fetches the component package from Fedora to fedpkg_cache_dir
+     2. Checks for existing SRPM or Koji task (returns early if found)
+     3. Prepares the specfile with bcond/macro patches
+     4. Submits a scratchbuild to Koji
+     5. Updates bcond_config with the Koji task ID
+    
+    Args:
+        component_name: Name of the component to build
+        bcond_config: Configuration dict with bcond settings and build cache identifier
+        branch: Git branch to use (defaults to config value)
+        target: Koji target to build for (optional)
+        no_git_refresh: Skip git refresh if True
+    
+    Returns:
+        bool: True if a scratchbuild was submitted, False if reusing existing artifact
+    """
+    repopath = pathlib.Path(CONFIG['cache_dir']['fedpkg']) / bcond_config['id']
+    
+    was_updated = refresh_or_clone(repopath, component_name, no_git_refresh=no_git_refresh, branch=branch)
+    
+    if check_existing_artifacts(repopath, was_updated, bcond_config):
+        return False
+    
+    prepare_spec_for_build(component_name, repopath, bcond_config)
+    
     bcond_config['koji_task_id'] = submit_scratchbuild(repopath, target=target)
     return True
 

--- a/bconds.py
+++ b/bconds.py
@@ -49,7 +49,7 @@ def srpm_path(directory):
     candidates = list(directory.glob('*.src.rpm'))
     if not candidates:
         return None
-    if count := len(candidates) > 1:
+    if (count := len(candidates)) > 1:
         raise RuntimeError(f'Found {count} SRPMs in {directory}.')
     return candidates[0]
 

--- a/bconds.py
+++ b/bconds.py
@@ -9,6 +9,13 @@ from gitrepo import clone_into, refresh_gitrepo, patch_spec, refresh_or_clone
 from utils import CONFIG, log, run
 
 KOJI_ID_FILENAME = 'koji.id'
+SRPM_EXTENSION = '.src.rpm'
+SPEC_EXTENSION = '.spec'
+
+KOJI_STATE_CLOSED = 'closed'
+KOJI_FAILED_STATES = ('canceled', 'failed')
+
+KOJI_ARTIFACT_RETENTION_DAYS = 7
 
 reverse_id_lookup = {}
 
@@ -46,7 +53,7 @@ def srpm_path(directory):
     Returns None if not there.
     Raises RuntimeError when multiple SRPMs are found.
     """
-    candidates = list(directory.glob('*.src.rpm'))
+    candidates = list(directory.glob(f'*{SRPM_EXTENSION}'))
     if not candidates:
         return None
     if (count := len(candidates)) > 1:
@@ -89,16 +96,13 @@ def koji_status(koji_id):
 
 def koji_id_is_older_than_week(koji_id_path):
     """
-    Returns True if koji_id file was created earlier than a week ago.
-    We assume this is a treshold time after which Koji artifacts are deleted,
+    Returns True if koji_id file was created earlier than the retention period.
+    We assume this is a threshold time after which Koji artifacts are deleted,
     and we need to remove koji_id to retrigger the scratchbuild.
-    If koji_id was created within the last week, return False.
     """
     koji_id_mtime = datetime.datetime.fromtimestamp(os.path.getmtime(koji_id_path))
-    one_week_ago = datetime.datetime.now() - datetime.timedelta(weeks=1)
-    if koji_id_mtime < one_week_ago:
-        return True
-    return False
+    retention_cutoff = datetime.datetime.now() - datetime.timedelta(days=KOJI_ARTIFACT_RETENTION_DAYS)
+    return koji_id_mtime < retention_cutoff
 
 
 def handle_existing_srpm(repopath, *, was_updated):
@@ -120,13 +124,13 @@ def handle_existing_koji_id(repopath, *, was_updated):
         else:
             koji_task_id = koji_id_path.read_text()
             status = koji_status(koji_task_id)
-            if status in ('canceled', 'failed'):
+            if status in KOJI_FAILED_STATES:
                 log(f'   • Koji task {koji_task_id} is {status}; '
                     f'removing {KOJI_ID_FILENAME}.')
                 koji_id_path.unlink()
                 return None
-            elif status == 'closed' and koji_id_is_older_than_week(koji_id_path):
-                log(f'   • Koji task {koji_task_id} is older than one week, '
+            elif status == KOJI_STATE_CLOSED and koji_id_is_older_than_week(koji_id_path):
+                log(f'   • Koji task {koji_task_id} is older than {KOJI_ARTIFACT_RETENTION_DAYS} days, '
                     f'there may be nothing to download; removing {KOJI_ID_FILENAME}.')
                 koji_id_path.unlink()
             else:
@@ -170,7 +174,7 @@ def prepare_spec_for_build(component_name, repopath, bcond_config):
     Returns:
         Path to the prepared spec file
     """
-    specpath = repopath / f'{component_name}.spec'
+    specpath = repopath / f'{component_name}{SPEC_EXTENSION}'
     patch_spec(specpath, bcond_config)
     
     if 'bootstrap' in bcond_config.get('withs', ()):
@@ -225,7 +229,7 @@ def download_srpm_if_possible(bcond_config):
     """
     if ('srpm' in bcond_config or
             'koji_task_id' not in bcond_config or
-            koji_status(bcond_config['koji_task_id']) != 'closed'):
+            koji_status(bcond_config['koji_task_id']) != KOJI_STATE_CLOSED):
         return False
     log(' • Downloading SRPM from Koji...', end=' ')
     repopath = pathlib.Path(CONFIG['cache_dir']['fedpkg']) / bcond_config['id']
@@ -234,8 +238,8 @@ def download_srpm_if_possible(bcond_config):
     if (l := len(koji_output)) != 1:
         raise RuntimeError(f'Cannot parse koji download-task output, expected 1 line, got: {l}')
     srpm_filename = koji_output[0].split(' ')[-1]
-    if not srpm_filename.endswith('.src.rpm'):
-        raise RuntimeError(f'Cannot parse koji download-task output, expected a *.src.rpm filename, got: {srpm_filename}')
+    if not srpm_filename.endswith(SRPM_EXTENSION):
+        raise RuntimeError(f'Cannot parse koji download-task output, expected a *{SRPM_EXTENSION} filename, got: {srpm_filename}')
     srpm = repopath / srpm_filename
     if not srpm.exists():
         raise RuntimeError(f'Downloaded SRPM does not exist: {srpm}')

--- a/bconds.py
+++ b/bconds.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import sys
 
-from gitrepo import clone_into, refresh_gitrepo, patch_spec, refresh_or_clone
+from gitrepo import patch_spec, refresh_or_clone
 from utils import CONFIG, log, run
 
 KOJI_ID_FILENAME = 'koji.id'

--- a/build.py
+++ b/build.py
@@ -2,62 +2,161 @@ import pathlib
 import sys
 
 from bconds import reverse_id_lookup, build_reverse_id_lookup
-from gitrepo import clone_into, refresh_gitrepo, patch_spec, refresh_or_clone
+from gitrepo import patch_spec, refresh_or_clone
 from utils import CONFIG, run
 
 
 PATCHDIR = pathlib.Path('patches_dir')
 FEDPKG_CACHEDIR = pathlib.Path(CONFIG['cache_dir']['fedpkg'])
+SPEC_EXTENSION = '.spec'
 
-if __name__ == '__main__':
-    try:
-        if len(sys.argv) != 2:
-            sys.exit('This requires one argument.')
-        component_name = sys.argv[1]
 
-        bootstrap = None
-        if ':' in component_name:
-            build_reverse_id_lookup()
-            bootstrap = reverse_id_lookup[component_name]
-            component_name, *_ = component_name.partition(':')
+def parse_component_argument(component_arg):
+    """
+    Parse component name and optional bcond configuration from argument.
+    
+    Args:
+        component_arg: Either a plain component name or bcond identifier
+    
+    Returns:
+        Tuple of (component_name, bootstrap_config or None)
+    """
+    if ':' not in component_arg:
+        return component_arg, None
+    
+    build_reverse_id_lookup()
+    bootstrap = reverse_id_lookup[component_arg]
+    component_name = component_arg.partition(':')[0]
+    return component_name, bootstrap
 
-        repopath = FEDPKG_CACHEDIR / component_name
-        refresh_or_clone(repopath, component_name, prune_existing=True)
 
-        specpath = repopath / f'{component_name}.spec'
+def get_patch_path(component_name):
+    """Get the path to a component's patch file."""
+    return PATCHDIR / f'{component_name}.patch'
 
-        # Find any patches from previous bootstrap builds
-        patch = PATCHDIR / f'{component_name}.patch'
-        if patch.exists():
-            if bootstrap:
-                raise NotImplementedError('Double bootstrap is not yet supported')
-            with patch.open('r') as patchfile:
-                run('patch', '-R', '-p1', stdin=patchfile, cwd=repopath)
-            patch.unlink()
 
+def get_spec_path(repopath, component_name):
+    """Get the path to a component's spec file."""
+    return repopath / f'{component_name}{SPEC_EXTENSION}'
+
+
+def revert_existing_patch(repopath, patch_path):
+    """
+    Revert an existing patch if it exists.
+    
+    Args:
+        repopath: Path to the repository
+        patch_path: Path to the patch file
+    
+    Raises:
+        NotImplementedError: If trying to apply double bootstrap
+    """
+    if not patch_path.exists():
+        return
+    
+    with patch_path.open('r') as patchfile:
+        run('patch', '-R', '-p1', stdin=patchfile, cwd=repopath)
+    patch_path.unlink()
+
+
+def prepare_bootstrap_build(repopath, component_name, specpath, bootstrap):
+    """
+    Prepare a bootstrap build by patching spec and saving diff.
+    
+    Args:
+        repopath: Path to the repository
+        component_name: Name of the component
+        specpath: Path to the spec file
+        bootstrap: Bootstrap configuration
+    
+    Returns:
+        str: Commit message for bootstrap build
+    """
+    message = CONFIG['distgit']['bootstrap_commit_message']
+    patch_spec(specpath, bootstrap)
+    diff = run('git', '-C', repopath, 'diff').stdout
+    patch_path = get_patch_path(component_name)
+    patch_path.write_text(diff)
+    return message
+
+
+def commit_and_push_changes(repopath, component_name, specpath, message):
+    """
+    Bump spec, commit changes, and push to remote.
+    
+    Args:
+        repopath: Path to the repository
+        component_name: Name of the component
+        specpath: Path to the spec file
+        message: Commit message
+    """
+    run('rpmdev-bumpspec', '-c', message, '--userstring', CONFIG['distgit']['author'], specpath)
+    run('git', '-C', repopath, 'commit', '--allow-empty', 
+        f'{component_name}{SPEC_EXTENSION}', '-m', message, 
+        '--author', CONFIG['distgit']['author'])
+    # raise NotImplementedError('no pushing yet')
+    run('git', '-C', repopath, 'push')
+
+
+def submit_koji_build(repopath):
+    """
+    Submit a Koji build for the component.
+    
+    Args:
+        repopath: Path to the repository
+    """
+    run('fedpkg', 'build', '--fail-fast', '--nowait', 
+        '--target', CONFIG['koji']['target'], cwd=repopath)  # '--background'
+
+
+def build_component(component_arg):
+    """
+    Build a component with optional bootstrap configuration.
+    
+    Args:
+        component_arg: Component name or bcond identifier (name:config)
+    
+    Raises:
+        NotImplementedError: If double bootstrap is attempted
+    """
+    component_name, bootstrap = parse_component_argument(component_arg)
+    repopath = FEDPKG_CACHEDIR / component_name
+    
+    refresh_or_clone(repopath, component_name, prune_existing=True)
+    
+    specpath = get_spec_path(repopath, component_name)
+    patch_path = get_patch_path(component_name)
+    
+    # Handle existing patches from previous builds
+    if patch_path.exists():
         if bootstrap:
-            message = CONFIG['distgit']['bootstrap_commit_message']
-            patch_spec(specpath, bootstrap)
-            diff = run('git', '-C', repopath, 'diff').stdout
-            patch.write_text(diff)
-        else:
-            message = CONFIG['distgit']['commit_message']
+            raise NotImplementedError('Double bootstrap is not yet supported')
+        revert_existing_patch(repopath, patch_path)
+    
+    if bootstrap:
+        message = prepare_bootstrap_build(repopath, component_name, specpath, bootstrap)
+    else:
+        message = CONFIG['distgit']['commit_message']
+    
+    # Bump and commit only if we haven't already, XXX ability to force this
+    head_commit_msg = run('git', '-C', repopath, 'log', '--format=%B', '-n1', 'HEAD').stdout.rstrip()
+    if bootstrap:  # or head_commit_msg != message:
+        commit_and_push_changes(repopath, component_name, specpath, message)
+    
+    submit_koji_build(repopath)
 
-        # Bump and commit only if we haven't already, XXX ability to force this
-        head_commit_msg = run('git', '-C', repopath, 'log', '--format=%B', '-n1', 'HEAD').stdout.rstrip()
-        if bootstrap:  # or head_commit_msg != message:
-            run('rpmdev-bumpspec', '-c', message, '--userstring', CONFIG['distgit']['author'], specpath)
-            run('git', '-C', repopath, 'commit', '--allow-empty', f'{component_name}.spec', '-m', message, '--author', CONFIG['distgit']['author'])
 
-            #raise NotImplementedError('no pushing yet')
-            run('git', '-C', repopath, 'push')
-        run('fedpkg', 'build', '--fail-fast', '--nowait', '--target', CONFIG['koji']['target'], cwd=repopath)  # '--background'
-
-        # XXX prune this directory because we don't want no thousands clones?
-        # maybe we are not gonna need this?
+def main():
+    """Main entry point for building components."""
+    if len(sys.argv) != 2:
+        sys.exit('Usage: build.py <component_name|bcond_identifier>')
+    
+    try:
+        build_component(sys.argv[1])
     except Exception:
         print(sys.argv[1])
         raise
 
-    # XXX prune this directory because we don't want no thousands clones?
-    # maybe we are not gonna need this?
+
+if __name__ == '__main__':
+    main()

--- a/gitrepo.py
+++ b/gitrepo.py
@@ -36,26 +36,106 @@ def refresh_gitrepo(repopath, prune_existing=False):
         return True
 
 
-def patch_spec(specpath, bcond_config):
-    log(f'   • Patching {specpath.name}')
+def validate_bcond_config(bcond_config):
+    """
+    Validate that bcond configuration doesn't have conflicting with/without.
+    
+    Args:
+        bcond_config: Configuration dict with 'withs' and 'withouts' keys
+    
+    Raises:
+        ValueError: If the same bcond appears in both 'withs' and 'withouts'
+    """
+    withs = set(bcond_config.get('withs', ()))
+    withouts = set(bcond_config.get('withouts', ()))
+    overlap = withs & withouts
+    
+    if overlap:
+        raise ValueError(f'Cannot have the same with and without: {", ".join(sorted(overlap))}')
 
-    run('git', '-C', specpath.parent, 'reset', '--hard')
 
-    spec_text = specpath.read_text()
-
+def generate_bcond_lines(bcond_config):
+    """
+    Generate RPM macro lines for bcond configuration.
+    
+    Args:
+        bcond_config: Configuration dict with 'withs' and 'withouts' keys
+    
+    Returns:
+        List of strings containing RPM macro definitions to prepend to spec
+    """
     lines = []
+    
     for without in sorted(bcond_config.get('withouts', ())):
-        if without in bcond_config.get('withs', ()):
-            raise ValueError(f'Cannot have the same with and without: {without}')
         lines.append(f'%global _without_{without} 1')
+    
     for with_ in sorted(bcond_config.get('withs', ())):
         lines.append(f'%global _with_{with_} 1')
-    for macro, value in bcond_config.get('replacements', {}).items():
-        spec_text = re.sub(fr'^(\s*)%(define|global)(\s+){macro}(\s+)\S.*$',
-                           fr'\1%\2\g<3>{macro}\g<4>{value}',
-                           spec_text, flags=re.MULTILINE)
-    lines.append(spec_text)
-    specpath.write_text('\n'.join(lines))
+    
+    return lines
+
+
+def apply_macro_replacements(spec_text, replacements):
+    """
+    Apply macro replacements to spec file text.
+    
+    Finds lines like '%define macro value' or '%global macro value' and
+    replaces the value with the one specified in replacements.
+    
+    Args:
+        spec_text: Original spec file text
+        replacements: Dict mapping macro names to new values
+    
+    Returns:
+        Modified spec file text with replacements applied
+    """
+    for macro, value in replacements.items():
+        # Escape the macro name in case it contains special regex characters
+        escaped_macro = re.escape(macro)
+        spec_text = re.sub(
+            fr'^(\s*)%(define|global)(\s+){escaped_macro}(\s+)\S.*$',
+            fr'\1%\2\g<3>{macro}\g<4>{value}',
+            spec_text,
+            flags=re.MULTILINE
+        )
+    
+    return spec_text
+
+
+def patch_spec(specpath, bcond_config):
+    """
+    Patch a spec file with bcond configuration and macro replacements.
+    
+    This function:
+    1. Resets any uncommitted changes in the repository
+    2. Validates bcond configuration
+    3. Generates bcond macro definitions to prepend
+    4. Applies macro replacements in the spec file
+    5. Writes the modified spec file
+    
+    Args:
+        specpath: Path to the spec file to patch
+        bcond_config: Configuration dict with:
+            - 'withs': list of bconds to enable (optional)
+            - 'withouts': list of bconds to disable (optional)
+            - 'replacements': dict of macro names to values (optional)
+    
+    Raises:
+        ValueError: If the same bcond appears in both withs and withouts
+    """
+    log(f'   • Patching {specpath.name}')
+    
+    run('git', '-C', specpath.parent, 'reset', '--hard')
+    
+    validate_bcond_config(bcond_config)
+    
+    spec_text = specpath.read_text()
+    spec_text = apply_macro_replacements(spec_text, bcond_config.get('replacements', {}))
+    
+    bcond_lines = generate_bcond_lines(bcond_config)
+    bcond_lines.append(spec_text)
+    
+    specpath.write_text('\n'.join(bcond_lines))
 
 
 def refresh_or_clone(repopath, component_name, *, prune_existing=False, no_git_refresh=False, branch=''):

--- a/jobs.py
+++ b/jobs.py
@@ -180,9 +180,10 @@ def _update_blocker_statistics(blocking_components, blocker_counter, loop_detect
     loop_detector[component] = sorted(blocking_components)
 
 
-def are_all_done(*, packages_to_check, all_components, components_done, blocker_counter, loop_detector, missing_packages):
+def are_all_done(*, component, packages_to_check, all_components, components_done, blocker_counter, loop_detector, missing_packages):
     """
-    Given a collection of (binary) packages_to_check, and dicts of all_components and components_done,
+    Given a component name and a collection of (binary) packages_to_check,
+    along with dicts of all_components and components_done,
     returns True if ALL packages_to_check are considered "done" (i.e. installable).
 
     missing_packages maps component names to sets of missing package names.
@@ -275,93 +276,215 @@ def get_component_status_info(component, missing_packages, components):
         return f" (build failed)"
 
 
-if __name__ == '__main__':
-    # this is spaghetti code that will be split into functions later:
-    from resolve_buildroot import resolve_buildrequires_of, resolve_requires
-    from bconds import bcond_cache_identifier, extract_buildrequires_if_possible
-
-    components = packages_to_rebuild(tuple(CONFIG['deps']['old']), excluded_components=tuple(CONFIG['components']['excluded']))
+def initialize_component_data():
+    """
+    Load and prepare all component data needed for rebuild analysis.
+    
+    Returns:
+        Tuple of (components, components_done, binary_rpms, blocker_counter, loop_detector, missing_packages)
+    """
+    components = packages_to_rebuild(
+        tuple(CONFIG['deps']['old']),
+        excluded_components=tuple(CONFIG['components']['excluded'])
+    )
     for component in CONFIG['components']['extra']:
         components[component] = []
-    components_done = packages_built(tuple(CONFIG['deps']['new']), excluded_components=tuple(CONFIG['components']['excluded']))
+    
+    components_done = packages_built(
+        tuple(CONFIG['deps']['new']),
+        excluded_components=tuple(CONFIG['components']['excluded'])
+    )
+    
     binary_rpms = components.all_values()
-
+    
     blocker_counter = {
         'general': collections.Counter(),
         'single': collections.Counter(),
         'combinations': collections.Counter(),
     }
     loop_detector = {}
-
     missing_packages = collections.defaultdict(set)  # requiring_component -> missing packages
+    
+    return components, components_done, binary_rpms, blocker_counter, loop_detector, missing_packages
 
-    for component in components:
-        if len(sys.argv) > 1 and component not in sys.argv[1:]:
-            continue
 
-        try:
-            component_buildroot = resolve_buildrequires_of(component)
-        except ValueError as e:
-            log(f'\n  ✗ {e}')
-            number_of_resolved = None
-            ready_to_rebuild = False
-        else:
-            number_of_resolved = len(component_buildroot)
+def check_regular_build(component, binary_rpms, components, components_done, blocker_counter, loop_detector, missing_packages):
+    """
+    Check if a component's regular (non-bconded) build is ready.
+    
+    Returns:
+        Tuple of (ready_to_rebuild, number_of_resolved)
+        - ready_to_rebuild: bool indicating if component can be rebuilt
+        - number_of_resolved: int count of resolved packages, or None if resolution failed
+    """
+    from resolve_buildroot import resolve_buildrequires_of
+    
+    try:
+        component_buildroot = resolve_buildrequires_of(component)
+    except ValueError as e:
+        log(f'\n  ✗ {e}')
+        return False, None
+    
+    number_of_resolved = len(component_buildroot)
+    ready_to_rebuild = are_all_done(
+        component=component,
+        packages_to_check=set(component_buildroot) & binary_rpms,
+        all_components=components,
+        components_done=components_done,
+        blocker_counter=blocker_counter,
+        loop_detector=loop_detector,
+        missing_packages=missing_packages,
+    )
+    
+    return ready_to_rebuild, number_of_resolved
 
-            ready_to_rebuild = are_all_done(
-                packages_to_check=set(component_buildroot) & binary_rpms,
-                all_components=components,
-                components_done=components_done,
-                blocker_counter=blocker_counter,
-                loop_detector=loop_detector,
-                missing_packages=missing_packages,
-            )
 
+def check_bcond_build(component, bcond_config, number_of_resolved, binary_rpms, components, components_done, blocker_counter, loop_detector, missing_packages):
+    """
+    Check if a component's bcond build is ready.
+    
+    Returns:
+        bool indicating if the bcond build can be rebuilt
+    """
+    from resolve_buildroot import resolve_requires
+    from bconds import extract_buildrequires_if_possible
+    
+    if 'buildrequires' not in bcond_config:
+        extract_buildrequires_if_possible(bcond_config)
+    
+    if 'buildrequires' not in bcond_config:
+        log(f' • {bcond_config["id"]} bcond SRPM not present yet, skipping')
+        return False
+    
+    try:
+        component_buildroot = resolve_requires(tuple(sorted(bcond_config['buildrequires'])))
+    except ValueError as e:
+        log(f'\n  ✗ {e}')
+        return False
+    
+    if number_of_resolved == len(component_buildroot):
+        # XXX when this happens, the bcond might be bogus
+        # figure out a way to present that information
+        pass
+    
+    ready_to_rebuild = are_all_done(
+        component=component,
+        packages_to_check=set(component_buildroot) & binary_rpms,
+        all_components=components,
+        components_done=components_done,
+        blocker_counter=blocker_counter,
+        loop_detector=loop_detector,
+        missing_packages=missing_packages,
+    )
+    
+    return ready_to_rebuild
+
+
+def check_bcond_builds(component, number_of_resolved, binary_rpms, components, components_done, blocker_counter, loop_detector, missing_packages):
+    """
+    Check all bcond builds for a component that isn't ready for regular build.
+    
+    Prints any bcond build identifiers that are ready to rebuild.
+    """
+    from bconds import bcond_cache_identifier
+    
+    if component not in CONFIG['bconds']:
+        return
+    
+    for bcond_config in CONFIG['bconds'][component]:
+        bcond_config['id'] = bcond_cache_identifier(component, bcond_config)
+        log(f'• {component} not ready and {bcond_config["id"]} bcond found, will check that one')
+        
+        ready_to_rebuild = check_bcond_build(
+            component, bcond_config, number_of_resolved,
+            binary_rpms, components, components_done,
+            blocker_counter, loop_detector, missing_packages
+        )
+        
         if ready_to_rebuild:
-            if os.environ.get('PRINT_ALL') or component not in components_done:
-                print(component)
-        elif component in CONFIG['bconds']:
-            for bcond_config in CONFIG['bconds'][component]:
-                bcond_config['id'] = bcond_cache_identifier(component, bcond_config)
-                log(f'• {component} not ready and {bcond_config["id"]} bcond found, will check that one')
-                if 'buildrequires' not in bcond_config:
-                    extract_buildrequires_if_possible(bcond_config)
-                if 'buildrequires' in bcond_config:
-                    try:
-                        component_buildroot = resolve_requires(tuple(sorted(bcond_config['buildrequires'])))
-                    except ValueError as e:
-                        log(f'\n  ✗ {e}')
-                        continue
-                    if number_of_resolved == len(component_buildroot):
-                        # XXX when this happens, the bcond might be bogus
-                        # figure out a way to present that information
-                        pass
-                    ready_to_rebuild = are_all_done(
-                        packages_to_check=set(component_buildroot) & binary_rpms,
-                        all_components=components,
-                        components_done=components_done,
-                        blocker_counter=blocker_counter,
-                        loop_detector=loop_detector,
-                        missing_packages=missing_packages,
-                    )
-                    if ready_to_rebuild:
-                        if os.environ.get('PRINT_ALL') or component not in components_done:
-                            print(bcond_config['id'])
-                else:
-                    log(f' • {bcond_config["id"]} bcond SRPM not present yet, skipping')
+            if should_print_component(component, components_done):
+                print(bcond_config['id'])
 
+
+def should_print_component(component, components_done):
+    """
+    Determine if a component should be printed based on PRINT_ALL env var.
+    
+    Returns:
+        bool indicating if component should be printed
+    """
+    return os.environ.get('PRINT_ALL') or component not in components_done
+
+
+def process_component(component, binary_rpms, components, components_done, blocker_counter, loop_detector, missing_packages):
+    """
+    Process a single component: check regular build and bcond builds if needed.
+    
+    Prints the component or bcond identifier if ready to rebuild.
+    """
+    ready_to_rebuild, number_of_resolved = check_regular_build(
+        component, binary_rpms, components, components_done,
+        blocker_counter, loop_detector, missing_packages
+    )
+    
+    if ready_to_rebuild:
+        if should_print_component(component, components_done):
+            print(component)
+    else:
+        check_bcond_builds(
+            component, number_of_resolved, binary_rpms,
+            components, components_done, blocker_counter,
+            loop_detector, missing_packages
+        )
+
+
+def generate_reports(blocker_counter, loop_detector, missing_packages, components):
+    """
+    Generate and print all summary reports.
+    """
     log('\nThe 50 most commonly needed components are:')
     for component, count in blocker_counter['general'].most_common(50):
         status_info = get_component_status_info(component, missing_packages, components)
         log(f'{count:>5} {component:<35} {status_info}')
-
+    
     log('\nThe 20 most commonly last-blocking components are:')
     for component, count in blocker_counter['single'].most_common(20):
         status_info = get_component_status_info(component, missing_packages, components)
         log(f'{count:>5} {component:<35} {status_info}')
-
+    
     log('\nThe 20 most commonly last-blocking small combinations of components are:')
-    for components, count in blocker_counter['combinations'].most_common(20):
-        log(f'{count:>5} {", ".join(components)}')
-
+    for components_tuple, count in blocker_counter['combinations'].most_common(20):
+        log(f'{count:>5} {", ".join(components_tuple)}')
+    
     report_blocking_components(loop_detector)
+
+
+def main():
+    """
+    Main entry point for rebuild analysis.
+    
+    Analyzes which components are ready to rebuild based on dependency resolution.
+    Prints ready components to stdout and detailed reports to stderr.
+    """
+    components, components_done, binary_rpms, blocker_counter, loop_detector, missing_packages = initialize_component_data()
+    
+    # Filter components based on command line arguments
+    components_to_process = components
+    if len(sys.argv) > 1:
+        components_to_process = {
+            comp: components[comp]
+            for comp in components
+            if comp in sys.argv[1:]
+        }
+    
+    for component in components_to_process:
+        process_component(
+            component, binary_rpms, components, components_done,
+            blocker_counter, loop_detector, missing_packages
+        )
+    
+    generate_reports(blocker_counter, loop_detector, missing_packages, components)
+
+
+if __name__ == '__main__':
+    main()

--- a/jobs.py
+++ b/jobs.py
@@ -110,6 +110,76 @@ def packages_built(new_deps, *, excluded_components=()):
     )
 
 
+def _group_packages_by_component(packages_to_check, all_components):
+    """
+    Group packages by their source component.
+    
+    Args:
+        packages_to_check: Collection of binary packages to check
+        all_components: ReverseLookupDict mapping components to packages
+    
+    Returns:
+        ReverseLookupDict with component names as keys and lists of packages as values
+    """
+    relevant_components = ReverseLookupDict()
+    for pkg in packages_to_check:
+        relevant_components[all_components.key(pkg)].append(pkg)
+    relevant_components.default_factory = None
+    return relevant_components
+
+
+def _is_package_available(required_package, done_packages):
+    """
+    Check if a required package is available in the list of done packages.
+    
+    The done packages are from a different repo and might have different EVR.
+    We compare by name or by virtual provides.
+    
+    Args:
+        required_package: The package we need
+        done_packages: List of packages that have been built
+    
+    Returns:
+        Tuple of (is_available, has_older_version)
+    """
+    has_older = False
+    for done_package in done_packages:
+        # The done packages are from different repo and might have different EVR
+        # Hence, we only compare the names
+        # For Copr rebuilds, the Copr EVR must be >= Fedora EVR
+        # For koji rebuilds, this will be always true anyway
+        if done_package.name == required_package.name:
+            # if not done_package.evr_lt(required_package):
+            if True:
+                return True, False
+            else:
+                has_older = True
+        else:
+            # Check the virtual provides - maybe one of them matches what we look for
+            for provide in done_package.provides:
+                if provide.name == required_package.name:
+                    return True, False
+    
+    return False, has_older
+
+
+def _update_blocker_statistics(blocking_components, blocker_counter, loop_detector, component):
+    """
+    Update blocker statistics based on which components are blocking.
+    
+    Args:
+        blocking_components: Set of component names that are blocking
+        blocker_counter: Dict with 'general', 'single', and 'combinations' counters
+        loop_detector: Dict mapping components to their blocking components
+        component: The component being checked
+    """
+    if len(blocking_components) == 1:
+        blocker_counter['single'][next(iter(blocking_components))] += 1
+    elif 1 < len(blocking_components) < 10:  # this is an arbitrarily chosen number to avoid cruft
+        blocker_counter['combinations'][tuple(sorted(blocking_components))] += 1
+    loop_detector[component] = sorted(blocking_components)
+
+
 def are_all_done(*, packages_to_check, all_components, components_done, blocker_counter, loop_detector, missing_packages):
     """
     Given a collection of (binary) packages_to_check, and dicts of all_components and components_done,
@@ -117,60 +187,41 @@ def are_all_done(*, packages_to_check, all_components, components_done, blocker_
 
     missing_packages maps component names to sets of missing package names.
     """
-    relevant_components = ReverseLookupDict()
-    for pkg in packages_to_check:
-        relevant_components[all_components.key(pkg)].append(pkg)
-    relevant_components.default_factory = None
+    relevant_components = _group_packages_by_component(packages_to_check, all_components)
 
     log(f'  • {component}: {len(packages_to_check)} packages / {len(relevant_components)} '
         f'components relevant to our problem')
+    
     all_available = True
     blocking_components = set()
+    
     for relevant_component, required_packages in relevant_components.items():
         log(f'    • {relevant_component}')
-        count_component = False
+        component_is_blocking = False
+        
         for required_package in required_packages:
-            has_older = False
-            for done_package in components_done.get(relevant_component, ()):
-                found = False
-                # The done packages are from different repo and might have different EVR
-                # Hence, we only compare the names
-                # For Copr rebuilds, the Copr EVR must be >= Fedora EVR
-                # For koji rebuilds, this will be always true anyway
-                if done_package.name == required_package.name:
-                    # if not done_package.evr_lt(required_package):
-                    if True:
-                        log(f'      ✔ {required_package.name}')
-                        break
-                    else:
-                        has_older = True
-                else:
-                    # Check the virtual provides - maybe one of them matches what we look for
-                    for provide in done_package.provides:
-                        if provide.name == required_package.name:
-                            log(f'      ✔ {required_package.name}')
-                            found = True
-                            break
-                    if found:
-                        break
+            is_available, has_older = _is_package_available(
+                required_package,
+                components_done.get(relevant_component, ())
+            )
+            
+            if is_available:
+                log(f'      ✔ {required_package.name}')
             else:
                 if has_older:
                     log(f'      ✗ {required_package.name} (older EVR available)')
                 else:
                     log(f'      ✗ {required_package.name}')
-
+                
                 missing_packages[component].add(required_package.name)
-
                 all_available = False
-                count_component = True
-        if count_component:
+                component_is_blocking = True
+        
+        if component_is_blocking:
             blocker_counter['general'][relevant_component] += 1
             blocking_components.add(relevant_component)
-    if len(blocking_components) == 1:
-        blocker_counter['single'][next(iter(blocking_components))] += 1
-    elif 1 < len(blocking_components) < 10:  # this is an arbitrarily chosen number to avoid cruft
-        blocker_counter['combinations'][tuple(sorted(blocking_components))] += 1
-    loop_detector[component] = sorted(blocking_components)
+    
+    _update_blocker_statistics(blocking_components, blocker_counter, loop_detector, component)
     return all_available
 
 

--- a/jobs.py
+++ b/jobs.py
@@ -37,6 +37,35 @@ class ReverseLookupDict(collections.defaultdict):
         return {value for lst in self.values() for value in lst}
 
 
+def _query_packages_by_deps(sack_getter, deps, excluded_components):
+    """
+    Common logic for querying packages by dependencies.
+    
+    Args:
+        sack_getter: Function that returns a DNF sack (e.g., rawhide_sack or target_sack)
+        deps: Hashable collection of string-dependencies to query
+        excluded_components: Hashable collection of component names to exclude
+    
+    Returns:
+        ReverseLookupDict with component names as keys and lists of hawkey.Packages as values
+    """
+    sack = sack_getter()
+    results = sack.query().filter(requires=deps, arch__neq='src', latest=1)
+    if CONFIG['architectures']['repoquery'] in MULTILIB:
+        results = results.filter(arch__neq=MULTILIB[CONFIG['architectures']['repoquery']])
+    components = ReverseLookupDict()
+    anticount = 0
+    for result in results:
+        if result.source_name not in excluded_components:
+            components[result.source_name].append(result)
+        else:
+            anticount += 1
+    # no longer create lists on access to avoid mistakes:
+    components.default_factory = None
+    log(f'found {len(components)} components ({len(results)-anticount} binary packages).')
+    return components
+
+
 @functools.lru_cache(maxsize=1)
 def packages_to_rebuild(old_deps, *, excluded_components=()):
     """
@@ -53,22 +82,12 @@ def packages_to_rebuild(old_deps, *, excluded_components=()):
     the dict will also contain packages that already successfully rebuilt
     (in our side tag or copr, etc.).
     """
-    sack = rawhide_sack()
     log('• Querying all packages to rebuild...', end=' ')
-    results = sack.query().filter(requires=old_deps, arch__neq='src', latest=1)
-    if CONFIG['architectures']['repoquery'] in MULTILIB:
-        results = results.filter(arch__neq=MULTILIB[CONFIG['architectures']['repoquery']])
-    components = ReverseLookupDict()
-    anticount = 0
-    for result in results:
-        if result.source_name not in excluded_components:
-            components[result.source_name].append(result)
-        else:
-            anticount += 1
-    # no longer create lists on access to avoid mistakes:
-    components.default_factory = None
-    log(f'found {len(components)} components ({len(results)-anticount} binary packages).')
-    return components
+    return _query_packages_by_deps(
+        rawhide_sack,
+        old_deps,
+        excluded_components,
+    )
 
 
 @functools.lru_cache(maxsize=1)
@@ -83,22 +102,12 @@ def packages_built(new_deps, *, excluded_components=()):
     Excluded_components is an optional hashable collection of component names
     to exclude from the results.
     """
-    sack = target_sack()
     log('• Querying all successfully rebuilt packages...', end=' ')
-    results = sack.query().filter(requires=new_deps, arch__neq='src', latest=1)
-    if CONFIG['architectures']['repoquery'] in MULTILIB:
-        results = results.filter(arch__neq=MULTILIB[CONFIG['architectures']['repoquery']])
-    components = ReverseLookupDict()
-    anticount = 0
-    for result in results:
-        if result.source_name not in excluded_components:
-            components[result.source_name].append(result)
-        else:
-            anticount += 1
-    # no longer create lists on access to avoid mistakes:
-    components.default_factory = None
-    log(f'found {len(components)} components ({len(results)-anticount} binary packages).')
-    return components
+    return _query_packages_by_deps(
+        target_sack,
+        new_deps,
+        excluded_components,
+    )
 
 
 def are_all_done(*, packages_to_check, all_components, components_done, blocker_counter, loop_detector, missing_packages):

--- a/jobs.py
+++ b/jobs.py
@@ -1,4 +1,5 @@
 import collections
+from dataclasses import dataclass, field
 import functools
 import os
 import sys
@@ -35,6 +36,31 @@ class ReverseLookupDict(collections.defaultdict):
 
     def all_values(self):
         return {value for lst in self.values() for value in lst}
+
+
+@dataclass
+class RebuildContext:
+    """
+    Context object holding all shared data and state for rebuild analysis.
+    
+    Attributes:
+        components: All components that need rebuilding (name -> list of packages)
+        components_done: Components that have been rebuilt (name -> list of packages)
+        binary_rpms: Set of all binary RPM packages to rebuild
+        blocker_counter: Statistics about blocking components
+        loop_detector: Map of components to their blocking components
+        missing_packages: Map of components to their missing package names
+    """
+    components: ReverseLookupDict
+    components_done: ReverseLookupDict
+    binary_rpms: set
+    blocker_counter: dict = field(default_factory=lambda: {
+        'general': collections.Counter(),
+        'single': collections.Counter(),
+        'combinations': collections.Counter(),
+    })
+    loop_detector: dict = field(default_factory=dict)
+    missing_packages: dict = field(default_factory=lambda: collections.defaultdict(set))
 
 
 def _query_packages_by_deps(sack_getter, deps, excluded_components):
@@ -180,15 +206,20 @@ def _update_blocker_statistics(blocking_components, blocker_counter, loop_detect
     loop_detector[component] = sorted(blocking_components)
 
 
-def are_all_done(*, component, packages_to_check, all_components, components_done, blocker_counter, loop_detector, missing_packages):
+def are_all_done(component, packages_to_check, ctx):
     """
     Given a component name and a collection of (binary) packages_to_check,
-    along with dicts of all_components and components_done,
-    returns True if ALL packages_to_check are considered "done" (i.e. installable).
-
-    missing_packages maps component names to sets of missing package names.
+    check if ALL packages are considered "done" (i.e. installable).
+    
+    Args:
+        component: Name of the component being checked
+        packages_to_check: Collection of binary packages to verify
+        ctx: RebuildContext with shared data and state
+    
+    Returns:
+        bool: True if ALL packages_to_check are considered "done" (i.e. installable).
     """
-    relevant_components = _group_packages_by_component(packages_to_check, all_components)
+    relevant_components = _group_packages_by_component(packages_to_check, ctx.components)
 
     log(f'  • {component}: {len(packages_to_check)} packages / {len(relevant_components)} '
         f'components relevant to our problem')
@@ -203,7 +234,7 @@ def are_all_done(*, component, packages_to_check, all_components, components_don
         for required_package in required_packages:
             is_available, has_older = _is_package_available(
                 required_package,
-                components_done.get(relevant_component, ())
+                ctx.components_done.get(relevant_component, ())
             )
             
             if is_available:
@@ -214,15 +245,15 @@ def are_all_done(*, component, packages_to_check, all_components, components_don
                 else:
                     log(f'      ✗ {required_package.name}')
                 
-                missing_packages[component].add(required_package.name)
+                ctx.missing_packages[component].add(required_package.name)
                 all_available = False
                 component_is_blocking = True
         
         if component_is_blocking:
-            blocker_counter['general'][relevant_component] += 1
+            ctx.blocker_counter['general'][relevant_component] += 1
             blocking_components.add(relevant_component)
     
-    _update_blocker_statistics(blocking_components, blocker_counter, loop_detector, component)
+    _update_blocker_statistics(blocking_components, ctx.blocker_counter, ctx.loop_detector, component)
     return all_available
 
 
@@ -281,7 +312,7 @@ def initialize_component_data():
     Load and prepare all component data needed for rebuild analysis.
     
     Returns:
-        Tuple of (components, components_done, binary_rpms, blocker_counter, loop_detector, missing_packages)
+        RebuildContext containing all component data and state
     """
     components = packages_to_rebuild(
         tuple(CONFIG['deps']['old']),
@@ -297,20 +328,20 @@ def initialize_component_data():
     
     binary_rpms = components.all_values()
     
-    blocker_counter = {
-        'general': collections.Counter(),
-        'single': collections.Counter(),
-        'combinations': collections.Counter(),
-    }
-    loop_detector = {}
-    missing_packages = collections.defaultdict(set)  # requiring_component -> missing packages
-    
-    return components, components_done, binary_rpms, blocker_counter, loop_detector, missing_packages
+    return RebuildContext(
+        components=components,
+        components_done=components_done,
+        binary_rpms=binary_rpms
+    )
 
 
-def check_regular_build(component, binary_rpms, components, components_done, blocker_counter, loop_detector, missing_packages):
+def check_regular_build(component, ctx):
     """
     Check if a component's regular (non-bconded) build is ready.
+    
+    Args:
+        component: Name of the component to check
+        ctx: RebuildContext with shared data and state
     
     Returns:
         Tuple of (ready_to_rebuild, number_of_resolved)
@@ -327,21 +358,23 @@ def check_regular_build(component, binary_rpms, components, components_done, blo
     
     number_of_resolved = len(component_buildroot)
     ready_to_rebuild = are_all_done(
-        component=component,
-        packages_to_check=set(component_buildroot) & binary_rpms,
-        all_components=components,
-        components_done=components_done,
-        blocker_counter=blocker_counter,
-        loop_detector=loop_detector,
-        missing_packages=missing_packages,
+        component,
+        set(component_buildroot) & ctx.binary_rpms,
+        ctx
     )
     
     return ready_to_rebuild, number_of_resolved
 
 
-def check_bcond_build(component, bcond_config, number_of_resolved, binary_rpms, components, components_done, blocker_counter, loop_detector, missing_packages):
+def check_bcond_build(component, bcond_config, number_of_resolved, ctx):
     """
     Check if a component's bcond build is ready.
+    
+    Args:
+        component: Name of the component to check
+        bcond_config: Bcond configuration dictionary
+        number_of_resolved: Number of packages in regular build (for comparison)
+        ctx: RebuildContext with shared data and state
     
     Returns:
         bool indicating if the bcond build can be rebuilt
@@ -368,21 +401,22 @@ def check_bcond_build(component, bcond_config, number_of_resolved, binary_rpms, 
         pass
     
     ready_to_rebuild = are_all_done(
-        component=component,
-        packages_to_check=set(component_buildroot) & binary_rpms,
-        all_components=components,
-        components_done=components_done,
-        blocker_counter=blocker_counter,
-        loop_detector=loop_detector,
-        missing_packages=missing_packages,
+        component,
+        set(component_buildroot) & ctx.binary_rpms,
+        ctx
     )
     
     return ready_to_rebuild
 
 
-def check_bcond_builds(component, number_of_resolved, binary_rpms, components, components_done, blocker_counter, loop_detector, missing_packages):
+def check_bcond_builds(component, number_of_resolved, ctx):
     """
     Check all bcond builds for a component that isn't ready for regular build.
+    
+    Args:
+        component: Name of the component to check
+        number_of_resolved: Number of packages in regular build (for comparison)
+        ctx: RebuildContext with shared data and state
     
     Prints any bcond build identifiers that are ready to rebuild.
     """
@@ -395,14 +429,10 @@ def check_bcond_builds(component, number_of_resolved, binary_rpms, components, c
         bcond_config['id'] = bcond_cache_identifier(component, bcond_config)
         log(f'• {component} not ready and {bcond_config["id"]} bcond found, will check that one')
         
-        ready_to_rebuild = check_bcond_build(
-            component, bcond_config, number_of_resolved,
-            binary_rpms, components, components_done,
-            blocker_counter, loop_detector, missing_packages
-        )
+        ready_to_rebuild = check_bcond_build(component, bcond_config, number_of_resolved, ctx)
         
         if ready_to_rebuild:
-            if should_print_component(component, components_done):
+            if should_print_component(component, ctx.components_done):
                 print(bcond_config['id'])
 
 
@@ -416,47 +446,47 @@ def should_print_component(component, components_done):
     return os.environ.get('PRINT_ALL') or component not in components_done
 
 
-def process_component(component, binary_rpms, components, components_done, blocker_counter, loop_detector, missing_packages):
+def process_component(component, ctx):
     """
     Process a single component: check regular build and bcond builds if needed.
     
+    Args:
+        component: Name of the component to process
+        ctx: RebuildContext with shared data and state
+    
     Prints the component or bcond identifier if ready to rebuild.
     """
-    ready_to_rebuild, number_of_resolved = check_regular_build(
-        component, binary_rpms, components, components_done,
-        blocker_counter, loop_detector, missing_packages
-    )
+    ready_to_rebuild, number_of_resolved = check_regular_build(component, ctx)
     
     if ready_to_rebuild:
-        if should_print_component(component, components_done):
+        if should_print_component(component, ctx.components_done):
             print(component)
     else:
-        check_bcond_builds(
-            component, number_of_resolved, binary_rpms,
-            components, components_done, blocker_counter,
-            loop_detector, missing_packages
-        )
+        check_bcond_builds(component, number_of_resolved, ctx)
 
 
-def generate_reports(blocker_counter, loop_detector, missing_packages, components):
+def generate_reports(ctx):
     """
     Generate and print all summary reports.
+    
+    Args:
+        ctx: RebuildContext with statistics and component data
     """
     log('\nThe 50 most commonly needed components are:')
-    for component, count in blocker_counter['general'].most_common(50):
-        status_info = get_component_status_info(component, missing_packages, components)
+    for component, count in ctx.blocker_counter['general'].most_common(50):
+        status_info = get_component_status_info(component, ctx.missing_packages, ctx.components)
         log(f'{count:>5} {component:<35} {status_info}')
     
     log('\nThe 20 most commonly last-blocking components are:')
-    for component, count in blocker_counter['single'].most_common(20):
-        status_info = get_component_status_info(component, missing_packages, components)
+    for component, count in ctx.blocker_counter['single'].most_common(20):
+        status_info = get_component_status_info(component, ctx.missing_packages, ctx.components)
         log(f'{count:>5} {component:<35} {status_info}')
     
     log('\nThe 20 most commonly last-blocking small combinations of components are:')
-    for components_tuple, count in blocker_counter['combinations'].most_common(20):
+    for components_tuple, count in ctx.blocker_counter['combinations'].most_common(20):
         log(f'{count:>5} {", ".join(components_tuple)}')
     
-    report_blocking_components(loop_detector)
+    report_blocking_components(ctx.loop_detector)
 
 
 def main():
@@ -466,24 +496,21 @@ def main():
     Analyzes which components are ready to rebuild based on dependency resolution.
     Prints ready components to stdout and detailed reports to stderr.
     """
-    components, components_done, binary_rpms, blocker_counter, loop_detector, missing_packages = initialize_component_data()
+    ctx = initialize_component_data()
     
     # Filter components based on command line arguments
-    components_to_process = components
+    components_to_process = ctx.components
     if len(sys.argv) > 1:
         components_to_process = {
-            comp: components[comp]
-            for comp in components
+            comp: ctx.components[comp]
+            for comp in ctx.components
             if comp in sys.argv[1:]
         }
     
     for component in components_to_process:
-        process_component(
-            component, binary_rpms, components, components_done,
-            blocker_counter, loop_detector, missing_packages
-        )
+        process_component(component, ctx)
     
-    generate_reports(blocker_counter, loop_detector, missing_packages, components)
+    generate_reports(ctx)
 
 
 if __name__ == '__main__':

--- a/jobs.py
+++ b/jobs.py
@@ -50,6 +50,7 @@ class RebuildContext:
         blocker_counter: Statistics about blocking components
         loop_detector: Map of components to their blocking components
         missing_packages: Map of components to their missing package names
+        unresolvable_components: Set of components whose dependencies cannot be resolved
     """
     components: ReverseLookupDict
     components_done: ReverseLookupDict
@@ -61,6 +62,7 @@ class RebuildContext:
     })
     loop_detector: dict = field(default_factory=dict)
     missing_packages: dict = field(default_factory=lambda: collections.defaultdict(set))
+    unresolvable_components: set = field(default_factory=set)
 
 
 def _query_packages_by_deps(sack_getter, deps, excluded_components):
@@ -289,9 +291,11 @@ def report_blocking_components(loop_detector):
         log('    • ' + ' → '.join(loop))
 
 
-def get_component_status_info(component, missing_packages, components):
+def get_component_status_info(component, missing_packages, components, unresolvable_components):
     """Generate status information for a component explaining why it's blocked."""
-    if component in components:
+    if component in unresolvable_components:
+        return " (can't resolve dependencies)"
+    elif component in components:
         if component in missing_packages:
             missing_deps = missing_packages[component]
             if missing_deps:
@@ -354,6 +358,7 @@ def check_regular_build(component, ctx):
         component_buildroot = resolve_buildrequires_of(component)
     except ValueError as e:
         log(f'\n  ✗ {e}')
+        ctx.unresolvable_components.add(component)
         return False, None
     
     number_of_resolved = len(component_buildroot)
@@ -393,6 +398,7 @@ def check_bcond_build(component, bcond_config, number_of_resolved, ctx):
         component_buildroot = resolve_requires(tuple(sorted(bcond_config['buildrequires'])))
     except ValueError as e:
         log(f'\n  ✗ {e}')
+        ctx.unresolvable_components.add(component)
         return False
     
     if number_of_resolved == len(component_buildroot):
@@ -474,12 +480,12 @@ def generate_reports(ctx):
     """
     log('\nThe 50 most commonly needed components are:')
     for component, count in ctx.blocker_counter['general'].most_common(50):
-        status_info = get_component_status_info(component, ctx.missing_packages, ctx.components)
+        status_info = get_component_status_info(component, ctx.missing_packages, ctx.components, ctx.unresolvable_components)
         log(f'{count:>5} {component:<35} {status_info}')
     
     log('\nThe 20 most commonly last-blocking components are:')
     for component, count in ctx.blocker_counter['single'].most_common(20):
-        status_info = get_component_status_info(component, ctx.missing_packages, ctx.components)
+        status_info = get_component_status_info(component, ctx.missing_packages, ctx.components, ctx.unresolvable_components)
         log(f'{count:>5} {component:<35} {status_info}')
     
     log('\nThe 20 most commonly last-blocking small combinations of components are:')

--- a/sacks.py
+++ b/sacks.py
@@ -5,6 +5,7 @@ import dnf
 from utils import CONFIG, log
 
 MULTILIB = {'x86_64': 'i686'} # architectures to exclude in certain queries
+ARCH = CONFIG['architectures']['repoquery']
 
 @functools.cache
 def _base(repo_key):
@@ -15,10 +16,10 @@ def _base(repo_key):
     """
     base = dnf.Base()
     dnf_conf = base.conf
-    dnf_conf.arch = CONFIG['architectures']['repoquery']
+    dnf_conf.arch = ARCH
     dnf_conf.cachedir = CONFIG['cache_dir']['dnf']
     dnf_conf.substitutions['releasever'] = 'rawhide'
-    dnf_conf.substitutions['basearch'] = CONFIG['architectures']['repoquery']
+    dnf_conf.substitutions['basearch'] = ARCH
     for repo in CONFIG['repos'][repo_key]:
         base.repos.add_new_repo(conf=dnf_conf, skip_if_unavailable=False, **repo)
     log(f'• Filling the DNF {repo_key} sack to/from {CONFIG["cache_dir"]["dnf"]}...', end=' ')

--- a/tests/test_bconds.py
+++ b/tests/test_bconds.py
@@ -1,0 +1,149 @@
+"""Tests for bconds module."""
+
+import datetime
+import pathlib
+from unittest.mock import Mock, patch
+import pytest
+
+from bconds import bcond_cache_identifier, koji_id_is_older_than_week
+
+
+class TestBcondCacheIdentifier:
+    """Tests for bcond_cache_identifier function."""
+    
+    def test_simple_component_no_bconds(self):
+        """Should generate identifier for component with no bconds."""
+        identifier = bcond_cache_identifier('mypackage', {})
+        assert identifier.startswith('mypackage:')
+        assert identifier == 'mypackage:::::'
+    
+    def test_with_withouts_only(self):
+        """Should include withouts in identifier."""
+        config = {'withouts': ['tests', 'docs']}
+        identifier = bcond_cache_identifier('pkg', config)
+        assert identifier == 'pkg:docs-tests::::'
+    
+    def test_with_withs_only(self):
+        """Should include withs in identifier."""
+        config = {'withs': ['bootstrap', 'feature']}
+        identifier = bcond_cache_identifier('pkg', config)
+        assert identifier == 'pkg::bootstrap-feature:::'
+    
+    def test_with_replacements_only(self):
+        """Should include replacement macro names in identifier."""
+        config = {'replacements': {'macro1': 'value1', 'macro2': 'value2'}}
+        identifier = bcond_cache_identifier('pkg', config)
+        assert identifier == 'pkg:::macro1-macro2::'
+    
+    def test_complete_config(self):
+        """Should include all parts in identifier."""
+        config = {
+            'withouts': ['tests', 'docs'],
+            'withs': ['bootstrap'],
+            'replacements': {'debug': '0'}
+        }
+        identifier = bcond_cache_identifier('pkg', config)
+        assert identifier == 'pkg:docs-tests:bootstrap:debug::'
+    
+    def test_canonical_ordering(self):
+        """Should generate same identifier regardless of input order."""
+        config1 = {
+            'withouts': ['tests', 'docs', 'man'],
+            'withs': ['feature', 'bootstrap']
+        }
+        config2 = {
+            'withouts': ['man', 'docs', 'tests'],
+            'withs': ['bootstrap', 'feature']
+        }
+        
+        id1 = bcond_cache_identifier('pkg', config1)
+        id2 = bcond_cache_identifier('pkg', config2)
+        assert id1 == id2
+        assert id1 == 'pkg:docs-man-tests:bootstrap-feature:::'
+    
+    def test_with_branch(self):
+        """Should include non-default branch in identifier."""
+        config = {'withs': ['bootstrap']}
+        identifier = bcond_cache_identifier('pkg', config, branch='f38')
+        assert identifier == 'pkg::bootstrap::f38:'
+    
+    def test_with_target(self):
+        """Should include target in identifier."""
+        config = {'withs': ['bootstrap']}
+        identifier = bcond_cache_identifier('pkg', config, target='f38-python')
+        assert identifier == 'pkg::bootstrap:::f38-python'
+    
+    @patch('bconds.CONFIG', {'distgit': {'branch': 'rawhide'}})
+    def test_default_branch_omitted(self):
+        """Should omit default branch from identifier."""
+        config = {}
+        identifier = bcond_cache_identifier('pkg', config, branch='rawhide')
+        # Default branch should be represented as empty string
+        assert identifier == 'pkg:::::'
+    
+    def test_single_bcond(self):
+        """Should handle single bcond correctly."""
+        config = {'withouts': ['tests']}
+        identifier = bcond_cache_identifier('pkg', config)
+        assert identifier == 'pkg:tests::::'
+    
+    def test_hyphen_separated(self):
+        """Should use hyphens to separate multiple options."""
+        config = {'withouts': ['a', 'b', 'c']}
+        identifier = bcond_cache_identifier('pkg', config)
+        assert 'a-b-c' in identifier
+
+
+class TestKojiIdIsOlderThanWeek:
+    """Tests for koji_id_is_older_than_week function."""
+    
+    def test_file_older_than_retention(self, tmp_path):
+        """Should return True for files older than retention period."""
+        koji_file = tmp_path / 'koji.id'
+        koji_file.write_text('12345')
+        
+        eight_days_ago = datetime.datetime.now() - datetime.timedelta(days=8)
+        
+        with patch('os.path.getmtime', return_value=eight_days_ago.timestamp()):
+            assert koji_id_is_older_than_week(koji_file)
+    
+    def test_file_newer_than_retention(self, tmp_path):
+        """Should return False for files newer than retention period."""
+        koji_file = tmp_path / 'koji.id'
+        koji_file.write_text('12345')
+        
+        five_days_ago = datetime.datetime.now() - datetime.timedelta(days=5)
+        
+        with patch('os.path.getmtime', return_value=five_days_ago.timestamp()):
+            assert not koji_id_is_older_than_week(koji_file)
+    
+    def test_file_exactly_at_retention(self, tmp_path):
+        """Should return True for files exactly at retention boundary (< not <=)."""
+        koji_file = tmp_path / 'koji.id'
+        koji_file.write_text('12345')
+
+        seven_days_ago = datetime.datetime.now() - datetime.timedelta(days=7)
+        
+        with patch('os.path.getmtime', return_value=seven_days_ago.timestamp()):
+            assert koji_id_is_older_than_week(koji_file)
+    
+    def test_very_old_file(self, tmp_path):
+        """Should return True for very old files."""
+        koji_file = tmp_path / 'koji.id'
+        koji_file.write_text('12345')
+        
+        thirty_days_ago = datetime.datetime.now() - datetime.timedelta(days=30)
+        
+        with patch('os.path.getmtime', return_value=thirty_days_ago.timestamp()):
+            assert koji_id_is_older_than_week(koji_file)
+    
+    def test_fresh_file(self, tmp_path):
+        """Should return False for freshly created files."""
+        koji_file = tmp_path / 'koji.id'
+        koji_file.write_text('12345')
+        
+        one_hour_ago = datetime.datetime.now() - datetime.timedelta(hours=1)
+        
+        with patch('os.path.getmtime', return_value=one_hour_ago.timestamp()):
+            assert not koji_id_is_older_than_week(koji_file)
+

--- a/tests/test_bconds.py
+++ b/tests/test_bconds.py
@@ -1,9 +1,7 @@
 """Tests for bconds module."""
 
 import datetime
-import pathlib
-from unittest.mock import Mock, patch
-import pytest
+from unittest.mock import patch
 
 from bconds import bcond_cache_identifier, koji_id_is_older_than_week
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,91 @@
+"""Tests for build module."""
+
+import pathlib
+import pytest
+from unittest.mock import Mock, patch
+
+from build import parse_component_argument, get_patch_path, get_spec_path
+
+
+class TestParseComponentArgument:
+    """Tests for parse_component_argument function."""
+    
+    def test_simple_component_name(self):
+        """Should parse simple component name without bcond."""
+        component, bootstrap = parse_component_argument('python-pytest')
+        assert component == 'python-pytest'
+        assert bootstrap is None
+    
+    @patch('build.build_reverse_id_lookup')
+    @patch('build.reverse_id_lookup', {'pkg:tests:::': {'withouts': ['tests']}})
+    def test_bcond_identifier(self, mock_build):
+        """Should parse bcond identifier and lookup config."""
+        component, bootstrap = parse_component_argument('pkg:tests:::')
+        assert component == 'pkg'
+        assert bootstrap == {'withouts': ['tests']}
+        mock_build.assert_called_once()
+    
+    @patch('build.build_reverse_id_lookup')
+    @patch('build.reverse_id_lookup', {'complex:docs-tests:bootstrap::': {'withouts': ['docs', 'tests'], 'withs': ['bootstrap']}})
+    def test_complex_bcond_identifier(self, mock_build):
+        """Should parse complex bcond identifier."""
+        component, bootstrap = parse_component_argument('complex:docs-tests:bootstrap::')
+        assert component == 'complex'
+        assert bootstrap == {'withouts': ['docs', 'tests'], 'withs': ['bootstrap']}
+    
+    def test_component_with_hyphen(self):
+        """Should handle component names with hyphens."""
+        component, bootstrap = parse_component_argument('python-some-package')
+        assert component == 'python-some-package'
+        assert bootstrap is None
+    
+    def test_component_with_number(self):
+        """Should handle component names with numbers."""
+        component, bootstrap = parse_component_argument('python3')
+        assert component == 'python3'
+        assert bootstrap is None
+
+
+class TestGetPatchPath:
+    """Tests for get_patch_path function."""
+    
+    def test_simple_component(self):
+        """Should generate correct patch path."""
+        path = get_patch_path('mypackage')
+        assert isinstance(path, pathlib.Path)
+        assert path.name == 'mypackage.patch'
+        assert 'patches_dir' in str(path)
+    
+    def test_component_with_hyphen(self):
+        """Should handle hyphens in component name."""
+        path = get_patch_path('python-pytest')
+        assert path.name == 'python-pytest.patch'
+        assert path.parent.name == 'patches_dir'
+
+
+class TestGetSpecPath:
+    """Tests for get_spec_path function."""
+    
+    def test_simple_spec_path(self):
+        """Should generate correct spec path."""
+        repopath = pathlib.Path('/tmp/repos/mypackage')
+        specpath = get_spec_path(repopath, 'mypackage')
+        
+        assert isinstance(specpath, pathlib.Path)
+        assert specpath.name == 'mypackage.spec'
+        assert specpath.parent == repopath
+    
+    def test_spec_path_with_hyphen(self):
+        """Should handle hyphens in component name."""
+        repopath = pathlib.Path('/tmp/repos/python-pytest')
+        specpath = get_spec_path(repopath, 'python-pytest')
+        
+        assert specpath.name == 'python-pytest.spec'
+    
+    def test_spec_path_relative(self):
+        """Should work with relative paths."""
+        repopath = pathlib.Path('repos/pkg')
+        specpath = get_spec_path(repopath, 'pkg')
+        
+        assert specpath == pathlib.Path('repos/pkg/pkg.spec')
+

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,8 +1,7 @@
 """Tests for build module."""
 
 import pathlib
-import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from build import parse_component_argument, get_patch_path, get_spec_path
 

--- a/tests/test_gitrepo.py
+++ b/tests/test_gitrepo.py
@@ -1,0 +1,205 @@
+"""Tests for gitrepo module."""
+
+import pytest
+
+from gitrepo import validate_bcond_config, generate_bcond_lines, apply_macro_replacements
+
+
+class TestValidateBcondConfig:
+    """Tests for validate_bcond_config function."""
+    
+    def test_no_conflict(self):
+        """Should not raise when withs and withouts don't overlap."""
+        config = {'withs': ['bootstrap'], 'withouts': ['tests']}
+        validate_bcond_config(config)
+    
+    def test_empty_config(self):
+        """Should not raise for empty configuration."""
+        config = {}
+        validate_bcond_config(config)
+    
+    def test_only_withs(self):
+        """Should not raise when only withs are specified."""
+        config = {'withs': ['bootstrap', 'feature']}
+        validate_bcond_config(config)
+    
+    def test_only_withouts(self):
+        """Should not raise when only withouts are specified."""
+        config = {'withouts': ['tests', 'docs']}
+        validate_bcond_config(config)
+    
+    def test_single_conflict(self):
+        """Should raise ValueError for single overlapping bcond."""
+        config = {'withs': ['bootstrap'], 'withouts': ['bootstrap']}
+        with pytest.raises(ValueError, match='Cannot have the same with and without: bootstrap'):
+            validate_bcond_config(config)
+    
+    def test_multiple_conflicts(self):
+        """Should raise ValueError listing all overlapping bconds."""
+        config = {
+            'withs': ['bootstrap', 'tests', 'feature'],
+            'withouts': ['tests', 'docs', 'feature']
+        }
+        with pytest.raises(ValueError) as exc_info:
+            validate_bcond_config(config)
+        
+        error_msg = str(exc_info.value)
+        assert 'feature' in error_msg
+        assert 'tests' in error_msg
+        assert 'bootstrap' not in error_msg  # bootstrap is not in conflict
+        assert 'docs' not in error_msg  # docs is not in conflict
+
+
+class TestGenerateBcondLines:
+    """Tests for generate_bcond_lines function."""
+    
+    def test_empty_config(self):
+        """Should return empty list for empty configuration."""
+        config = {}
+        assert generate_bcond_lines(config) == []
+    
+    def test_only_withouts(self):
+        """Should generate only _without_* macros."""
+        config = {'withouts': ['tests', 'docs']}
+        lines = generate_bcond_lines(config)
+        assert lines == [
+            '%global _without_docs 1',
+            '%global _without_tests 1'
+        ]
+    
+    def test_only_withs(self):
+        """Should generate only _with_* macros."""
+        config = {'withs': ['bootstrap', 'feature']}
+        lines = generate_bcond_lines(config)
+        assert lines == [
+            '%global _with_bootstrap 1',
+            '%global _with_feature 1'
+        ]
+    
+    def test_both_withs_and_withouts(self):
+        """Should generate both types of macros in correct order."""
+        config = {
+            'withouts': ['tests', 'docs'],
+            'withs': ['bootstrap']
+        }
+        lines = generate_bcond_lines(config)
+        assert lines == [
+            '%global _without_docs 1',
+            '%global _without_tests 1',
+            '%global _with_bootstrap 1'
+        ]
+    
+    def test_sorted_output(self):
+        """Should sort bconds alphabetically."""
+        config = {
+            'withouts': ['zed', 'alpha', 'middle'],
+            'withs': ['zebra', 'aardvark']
+        }
+        lines = generate_bcond_lines(config)
+        assert lines == [
+            '%global _without_alpha 1',
+            '%global _without_middle 1',
+            '%global _without_zed 1',
+            '%global _with_aardvark 1',
+            '%global _with_zebra 1'
+        ]
+    
+    def test_single_bcond(self):
+        """Should handle single bcond correctly."""
+        config = {'withouts': ['tests']}
+        lines = generate_bcond_lines(config)
+        assert lines == ['%global _without_tests 1']
+
+
+class TestApplyMacroReplacements:
+    """Tests for apply_macro_replacements function."""
+    
+    def test_no_replacements(self):
+        """Should return unchanged text when no replacements."""
+        spec_text = '%global version 1.0\n%define release 1'
+        result = apply_macro_replacements(spec_text, {})
+        assert result == spec_text
+    
+    def test_simple_global_replacement(self):
+        """Should replace %global macro value."""
+        spec_text = '%global version 1.0'
+        replacements = {'version': '2.0'}
+        result = apply_macro_replacements(spec_text, replacements)
+        assert result == '%global version 2.0'
+    
+    def test_simple_define_replacement(self):
+        """Should replace %define macro value."""
+        spec_text = '%define release 1'
+        replacements = {'release': '2'}
+        result = apply_macro_replacements(spec_text, replacements)
+        assert result == '%define release 2'
+    
+    def test_multiple_replacements(self):
+        """Should handle multiple macro replacements."""
+        spec_text = '''%global version 1.0
+%define release 1
+%global someflag 0'''
+        replacements = {'version': '2.0', 'someflag': '1'}
+        result = apply_macro_replacements(spec_text, replacements)
+        expected = '''%global version 2.0
+%define release 1
+%global someflag 1'''
+        assert result == expected
+    
+    def test_macro_with_special_chars(self):
+        """Should handle macro names with special regex characters."""
+        spec_text = '%global some.macro 0'
+        replacements = {'some.macro': '1'}
+        result = apply_macro_replacements(spec_text, replacements)
+        assert result == '%global some.macro 1'
+    
+    def test_macro_with_underscores(self):
+        """Should handle macro names with underscores."""
+        spec_text = '%global _with_feature 0'
+        replacements = {'_with_feature': '1'}
+        result = apply_macro_replacements(spec_text, replacements)
+        assert result == '%global _with_feature 1'
+    
+    def test_preserves_indentation(self):
+        """Should preserve leading whitespace."""
+        spec_text = '  %global version 1.0\n\t%define release 1'
+        replacements = {'version': '2.0'}
+        result = apply_macro_replacements(spec_text, replacements)
+        assert result == '  %global version 2.0\n\t%define release 1'
+    
+    def test_preserves_spacing(self):
+        """Should preserve spacing between elements."""
+        spec_text = '%global  version   1.0'
+        replacements = {'version': '2.0'}
+        result = apply_macro_replacements(spec_text, replacements)
+        # The regex should preserve the spacing structure
+        assert '%global' in result
+        assert 'version' in result
+        assert '2.0' in result
+    
+    def test_only_replaces_matching_macro(self):
+        """Should only replace the specified macro, not similar ones."""
+        spec_text = '''%global version 1.0
+%global version_major 1
+%global my_version 1.0'''
+        replacements = {'version': '2.0'}
+        result = apply_macro_replacements(spec_text, replacements)
+        expected = '''%global version 2.0
+%global version_major 1
+%global my_version 1.0'''
+        assert result == expected
+    
+    def test_multiline_spec(self):
+        """Should work correctly with multiline spec files."""
+        spec_text = '''Name: mypackage
+Version: 1.0
+%global debug_package %{nil}
+%global with_tests 0
+
+Summary: A test package'''
+        replacements = {'with_tests': '1'}
+        result = apply_macro_replacements(spec_text, replacements)
+        assert '%global with_tests 1' in result
+        assert 'Name: mypackage' in result
+        assert 'Summary: A test package' in result
+

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,174 @@
+"""Tests for jobs module."""
+
+import pytest
+
+from jobs import ReverseLookupDict, get_component_status_info
+
+
+class TestReverseLookupDict:
+    """Tests for ReverseLookupDict class."""
+    
+    def test_basic_usage(self):
+        """Should work as a defaultdict(list)."""
+        rld = ReverseLookupDict()
+        rld['key1'].append('value1')
+        rld['key1'].append('value2')
+        rld['key2'].append('value3')
+        
+        assert rld['key1'] == ['value1', 'value2']
+        assert rld['key2'] == ['value3']
+    
+    def test_key_lookup(self):
+        """Should be able to reverse-lookup keys from values."""
+        rld = ReverseLookupDict()
+        rld['component1'].append('pkg1')
+        rld['component1'].append('pkg2')
+        rld['component2'].append('pkg3')
+        
+        assert rld.key('pkg1') == 'component1'
+        assert rld.key('pkg2') == 'component1'
+        assert rld.key('pkg3') == 'component2'
+    
+    def test_key_lookup_caches(self):
+        """Should cache reverse lookups."""
+        rld = ReverseLookupDict()
+        rld['key1'].append('value1')
+        
+        # First lookup
+        result1 = rld.key('value1')
+        # Second lookup should use cache
+        result2 = rld.key('value1')
+        
+        assert result1 == result2 == 'key1'
+        assert 'value1' in rld._reverse_lookup_cache
+    
+    def test_key_lookup_not_found(self):
+        """Should raise KeyError for values not in any list."""
+        rld = ReverseLookupDict()
+        rld['key1'].append('value1')
+        
+        with pytest.raises(KeyError, match="Value 'nonexistent' found in no list"):
+            rld.key('nonexistent')
+    
+    def test_all_values(self):
+        """Should return set of all values across all keys."""
+        rld = ReverseLookupDict()
+        rld['key1'].append('value1')
+        rld['key1'].append('value2')
+        rld['key2'].append('value3')
+        rld['key2'].append('value4')
+        
+        all_vals = rld.all_values()
+        assert all_vals == {'value1', 'value2', 'value3', 'value4'}
+    
+    def test_all_values_empty(self):
+        """Should return empty set for empty dict."""
+        rld = ReverseLookupDict()
+        assert rld.all_values() == set()
+    
+    def test_all_values_deduplicates(self):
+        """Should return unique values even if duplicated across keys."""
+        rld = ReverseLookupDict()
+        rld['key1'].append('value1')
+        rld['key2'].append('value1')  # Duplicate
+        rld['key3'].append('value2')
+        
+        all_vals = rld.all_values()
+        assert all_vals == {'value1', 'value2'}
+    
+    def test_default_factory_can_be_disabled(self):
+        """Should be able to disable auto-creation of lists."""
+        rld = ReverseLookupDict()
+        rld['key1'].append('value1')
+        
+        # Disable default factory
+        rld.default_factory = None
+        
+        # Now accessing non-existent key should raise KeyError
+        with pytest.raises(KeyError):
+            _ = rld['nonexistent']
+    
+    def test_multiple_values_per_key(self):
+        """Should handle multiple values per key."""
+        rld = ReverseLookupDict()
+        values = ['v1', 'v2', 'v3', 'v4', 'v5']
+        for val in values:
+            rld['key1'].append(val)
+        
+        assert rld['key1'] == values
+        for val in values:
+            assert rld.key(val) == 'key1'
+
+
+class TestGetComponentStatusInfo:
+    """Tests for get_component_status_info function."""
+    
+    def test_component_blocked_with_missing_packages(self):
+        """Should show blocked status with missing packages."""
+        missing_packages = {'comp1': {'pkg1', 'pkg2', 'pkg3'}}
+        components = {'comp1': ['some_pkg']}
+        
+        status = get_component_status_info('comp1', missing_packages, components)
+        assert '(blocked by:' in status
+        # Should show first 3 packages
+        assert any(pkg in status for pkg in ['pkg1', 'pkg2', 'pkg3'])
+    
+    def test_component_blocked_with_many_packages(self):
+        """Should truncate and add ... for many missing packages."""
+        missing_packages = {'comp1': {f'pkg{i}' for i in range(10)}}
+        components = {'comp1': ['some_pkg']}
+        
+        status = get_component_status_info('comp1', missing_packages, components)
+        assert '(blocked by:' in status
+        assert '...' in status
+    
+    def test_component_blocked_unknown_reason(self):
+        """Should show unknown reason if in missing_packages but empty."""
+        missing_packages = {'comp1': set()}
+        components = {'comp1': ['some_pkg']}
+        
+        status = get_component_status_info('comp1', missing_packages, components)
+        assert '(blocked for unknown reason)' in status
+    
+    def test_component_ready(self):
+        """Should show ready status if in components but not in missing_packages."""
+        missing_packages = {}
+        components = {'comp1': ['some_pkg']}
+        
+        status = get_component_status_info('comp1', missing_packages, components)
+        assert '(ready)' in status
+    
+    def test_component_build_failed(self):
+        """Should show build failed if not in components."""
+        missing_packages = {}
+        components = {}
+        
+        status = get_component_status_info('comp1', missing_packages, components)
+        assert '(build failed)' in status
+    
+    def test_blocked_with_few_packages(self):
+        """Should show all packages if 3 or fewer."""
+        missing_packages = {'comp1': {'pkg1', 'pkg2'}}
+        components = {'comp1': ['some_pkg']}
+        
+        status = get_component_status_info('comp1', missing_packages, components)
+        assert 'pkg1' in status
+        assert 'pkg2' in status
+        assert '...' not in status
+    
+    def test_blocked_with_exactly_three_packages(self):
+        """Should show all 3 packages without truncation."""
+        missing_packages = {'comp1': {'pkg1', 'pkg2', 'pkg3'}}
+        components = {'comp1': ['some_pkg']}
+        
+        status = get_component_status_info('comp1', missing_packages, components)
+        assert '...' not in status
+    
+    def test_blocked_with_four_packages(self):
+        """Should truncate at 4 packages."""
+        missing_packages = {'comp1': {'pkg1', 'pkg2', 'pkg3', 'pkg4'}}
+        components = {'comp1': ['some_pkg']}
+        
+        status = get_component_status_info('comp1', missing_packages, components)
+        assert '...' in status
+

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -107,8 +107,9 @@ class TestGetComponentStatusInfo:
         """Should show blocked status with missing packages."""
         missing_packages = {'comp1': {'pkg1', 'pkg2', 'pkg3'}}
         components = {'comp1': ['some_pkg']}
+        unresolvable_components = set()
         
-        status = get_component_status_info('comp1', missing_packages, components)
+        status = get_component_status_info('comp1', missing_packages, components, unresolvable_components)
         assert '(blocked by:' in status
         # Should show first 3 packages
         assert any(pkg in status for pkg in ['pkg1', 'pkg2', 'pkg3'])
@@ -117,8 +118,9 @@ class TestGetComponentStatusInfo:
         """Should truncate and add ... for many missing packages."""
         missing_packages = {'comp1': {f'pkg{i}' for i in range(10)}}
         components = {'comp1': ['some_pkg']}
+        unresolvable_components = set()
         
-        status = get_component_status_info('comp1', missing_packages, components)
+        status = get_component_status_info('comp1', missing_packages, components, unresolvable_components)
         assert '(blocked by:' in status
         assert '...' in status
     
@@ -126,32 +128,45 @@ class TestGetComponentStatusInfo:
         """Should show unknown reason if in missing_packages but empty."""
         missing_packages = {'comp1': set()}
         components = {'comp1': ['some_pkg']}
+        unresolvable_components = set()
         
-        status = get_component_status_info('comp1', missing_packages, components)
+        status = get_component_status_info('comp1', missing_packages, components, unresolvable_components)
         assert '(blocked for unknown reason)' in status
     
     def test_component_ready(self):
         """Should show ready status if in components but not in missing_packages."""
         missing_packages = {}
         components = {'comp1': ['some_pkg']}
+        unresolvable_components = set()
         
-        status = get_component_status_info('comp1', missing_packages, components)
+        status = get_component_status_info('comp1', missing_packages, components, unresolvable_components)
         assert '(ready)' in status
     
     def test_component_build_failed(self):
         """Should show build failed if not in components."""
         missing_packages = {}
         components = {}
+        unresolvable_components = set()
         
-        status = get_component_status_info('comp1', missing_packages, components)
+        status = get_component_status_info('comp1', missing_packages, components, unresolvable_components)
         assert '(build failed)' in status
     
+    def test_component_unresolvable(self):
+        """Should show can't resolve dependencies if in unresolvable_components."""
+        missing_packages = {}
+        components = {'comp1': ['some_pkg']}
+        unresolvable_components = {'comp1'}
+
+        status = get_component_status_info('comp1', missing_packages, components, unresolvable_components)
+        assert "(can't resolve dependencies)" in status
+
     def test_blocked_with_few_packages(self):
         """Should show all packages if 3 or fewer."""
         missing_packages = {'comp1': {'pkg1', 'pkg2'}}
         components = {'comp1': ['some_pkg']}
+        unresolvable_components = set()
         
-        status = get_component_status_info('comp1', missing_packages, components)
+        status = get_component_status_info('comp1', missing_packages, components, unresolvable_components)
         assert 'pkg1' in status
         assert 'pkg2' in status
         assert '...' not in status
@@ -160,15 +175,17 @@ class TestGetComponentStatusInfo:
         """Should show all 3 packages without truncation."""
         missing_packages = {'comp1': {'pkg1', 'pkg2', 'pkg3'}}
         components = {'comp1': ['some_pkg']}
+        unresolvable_components = set()
         
-        status = get_component_status_info('comp1', missing_packages, components)
+        status = get_component_status_info('comp1', missing_packages, components, unresolvable_components)
         assert '...' not in status
     
     def test_blocked_with_four_packages(self):
         """Should truncate at 4 packages."""
         missing_packages = {'comp1': {'pkg1', 'pkg2', 'pkg3', 'pkg4'}}
         components = {'comp1': ['some_pkg']}
+        unresolvable_components = set()
         
-        status = get_component_status_info('comp1', missing_packages, components)
+        status = get_component_status_info('comp1', missing_packages, components, unresolvable_components)
         assert '...' in status
 

--- a/tests/test_resolve_buildroot.py
+++ b/tests/test_resolve_buildroot.py
@@ -37,7 +37,7 @@ def test_mandatory_packages_in_groups_contains_limited_number_of_packages():
 # XXX this test has data copied from simple specfiles, but it can change
 @pytest.mark.parametrize('package_name, expected', [
     ('fedora-obsolete-packages', ()),
-    ('fedora-repos', ('gnupg', 'sed')),
+    ('fedora-repos', ('gnupg', 'rpm', 'sed')),
     ('fedora-release', ('redhat-rpm-config > 121-1', 'systemd-rpm-macros')),
     ('redhat-rpm-config', ('perl-generators',)),
 ])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,118 @@
+"""Tests for utils module."""
+
+from unittest.mock import Mock
+import pytest
+
+from utils import name_or_str, stringify
+
+
+class TestNameOrStr:
+    """Tests for name_or_str function."""
+    
+    def test_object_with_name_attribute(self):
+        """Should return name attribute if present."""
+        obj = Mock()
+        obj.name = 'test_name'
+        assert name_or_str(obj) == 'test_name'
+    
+    def test_object_without_name_attribute(self):
+        """Should return str() representation if no name attribute."""
+        # Use a simple class without name attribute
+        class NoNameObj:
+            def __str__(self):
+                return 'string_repr'
+        
+        obj = NoNameObj()
+        assert name_or_str(obj) == 'string_repr'
+    
+    def test_simple_string(self):
+        """Should return string as-is."""
+        assert name_or_str('hello') == 'hello'
+    
+    def test_number(self):
+        """Should convert number to string."""
+        assert name_or_str(42) == '42'
+    
+    def test_hawkey_package_like(self):
+        """Should work with objects that have name like hawkey.Package."""
+        pkg = Mock()
+        pkg.name = 'python3-pytest'
+        pkg.version = '7.4.0'
+        assert name_or_str(pkg) == 'python3-pytest'
+    
+    def test_none_value(self):
+        """Should convert None to string."""
+        result = name_or_str(None)
+        assert result == 'None'
+
+
+class TestStringify:
+    """Tests for stringify function."""
+    
+    def test_empty_list(self):
+        """Should return empty string for empty list."""
+        assert stringify([]) == ''
+    
+    def test_single_item(self):
+        """Should return single item as string."""
+        assert stringify(['item1']) == 'item1'
+    
+    def test_multiple_items_default_separator(self):
+        """Should join items with comma and space by default."""
+        items = ['item1', 'item2', 'item3']
+        assert stringify(items) == 'item1, item2, item3'
+    
+    def test_custom_separator(self):
+        """Should use custom separator when provided."""
+        items = ['item1', 'item2', 'item3']
+        assert stringify(items, '\n') == 'item1\nitem2\nitem3'
+    
+    def test_objects_with_name_attribute(self):
+        """Should extract name from objects."""
+        obj1 = Mock()
+        obj1.name = 'package1'
+        obj2 = Mock()
+        obj2.name = 'package2'
+        
+        result = stringify([obj1, obj2])
+        assert result == 'package1, package2'
+    
+    def test_mixed_objects_and_strings(self):
+        """Should handle mix of objects and strings."""
+        obj = Mock()
+        obj.name = 'package1'
+        
+        result = stringify([obj, 'string_item'])
+        assert result == 'package1, string_item'
+    
+    def test_numbers(self):
+        """Should convert numbers to strings."""
+        items = [1, 2, 3]
+        assert stringify(items) == '1, 2, 3'
+    
+    def test_newline_separator(self):
+        """Should work with newline separator."""
+        items = ['pkg1', 'pkg2', 'pkg3']
+        result = stringify(items, '\n')
+        assert result == 'pkg1\npkg2\npkg3'
+    
+    def test_pipe_separator(self):
+        """Should work with pipe separator."""
+        items = ['a', 'b', 'c']
+        assert stringify(items, '|') == 'a|b|c'
+    
+    def test_empty_separator(self):
+        """Should concatenate with no separator."""
+        items = ['a', 'b', 'c']
+        assert stringify(items, '') == 'abc'
+    
+    def test_generator_input(self):
+        """Should work with generator expressions."""
+        gen = (x for x in ['a', 'b', 'c'])
+        assert stringify(gen) == 'a, b, c'
+    
+    def test_tuple_input(self):
+        """Should work with tuples."""
+        items = ('x', 'y', 'z')
+        assert stringify(items) == 'x, y, z'
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 """Tests for utils module."""
 
 from unittest.mock import Mock
-import pytest
 
 from utils import name_or_str, stringify
 


### PR DESCRIPTION
A bigger refactor of the scripts, most importantly it breaks down spaghetti into logical chunks; new functions are now also tested, bringing more visibility into the state of code. Also, some fixes and renames happened on the go.
Used LLM for refactoring extensively, disclosed in particular commits with `Assisted-By` line.
I reviewed the changes commit-by-commit; the logic should remain the same. Whether to go into such granularity as below, is to discuss:

```
def get_patch_path(component_name):
    """Get the path to a component's patch file."""
    return PATCHDIR / f'{component_name}.patch'


def get_spec_path(repopath, component_name):
    """Get the path to a component's spec file."""
    return repopath / f'{component_name}{SPEC_EXTENSION}'
```

Overall, as the script is the cornerstone of the rebuild, but doesn't move much in terms of readability and maintainability, I think it deserves more love. I'm open to suggestions to change/improve.
Best to review commit-by-commit.